### PR TITLE
게시판 api 만들기 - DATA REST 적용 및 테스트 정의

### DIFF
--- a/src/main/java/com/jpa/board/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/jpa/board/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.jpa.board.repository;
 
 import com.jpa.board.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/jpa/board/repository/ArticleRepository.java
+++ b/src/main/java/com/jpa/board/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.jpa.board.repository;
 
 import com.jpa.board.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,6 @@ spring.jpa.database=oracle
 spring.jpa.database-platform=org.hibernate.dialect.Oracle10gDialect
 spring.sql.init.mode=always
 spring.test.database.replace=none
+
+spring.data.rest.base-path=/api
+spring.data.rest.detection-strategy=annotated

--- a/src/test/java/com/jpa/board/controller/DataRestTest.java
+++ b/src/test/java/com/jpa/board/controller/DataRestTest.java
@@ -1,0 +1,91 @@
+package com.jpa.board.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@DisplayName("Data Rest 테스트")
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    public void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        // given
+
+        // when
+        mvc.perform(MockMvcRequestBuilders.get("/api/articles"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(MockMvcResultHandlers.print());
+        // test
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    public void givenArticleNumber_whenRequestingArticles_thenReturnsArticleJsonResponse() throws Exception {
+        // given
+
+        // when
+        mvc.perform(MockMvcRequestBuilders.get("/api/articles/2"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(MockMvcResultHandlers.print());
+        // test
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    public void givenArticleNumber_whenRequestingArticles_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // given
+
+        // when
+        mvc.perform(MockMvcRequestBuilders.get("/api/articles/2/articleComments"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(MockMvcResultHandlers.print());
+        // test
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    public void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // given
+
+        // when
+        mvc.perform(MockMvcRequestBuilders.get("/api/articleComments"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(MockMvcResultHandlers.print());
+        // test
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    public void givenArticleCommentId_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        // given
+
+        // when
+        mvc.perform(MockMvcRequestBuilders.get("/api/articleComments/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(MockMvcResultHandlers.print());
+        // test
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data Rest로 서비스하고 해당 api들의 존재 여부만 체크하게끔 통합 테스트 작성
