### PR TITLE
#23 - 게시글 페이지네이션 구현

### DIFF
--- a/src/main/java/com/jpa/board/controller/ArticleController.java
+++ b/src/main/java/com/jpa/board/controller/ArticleController.java
@@ -46,6 +46,8 @@ public class ArticleController {
         ArticleWithCommentResponse article = ArticleWithCommentResponse.from(articleService.getArticle(articleId));
         model.addAttribute("article", article);
         model.addAttribute("articleComments", article.getArticleCommentResponses());
+        model.addAttribute("totalCount", articleService.getArticleCount());
+
         return "articles/detail";
     }
 

--- a/src/main/java/com/jpa/board/repository/ArticleRepository.java
+++ b/src/main/java/com/jpa/board/repository/ArticleRepository.java
@@ -3,7 +3,6 @@ package com.jpa.board.repository;
 import com.jpa.board.domain.Article;
 import com.jpa.board.domain.QArticle;
 import com.querydsl.core.types.dsl.DateTimeExpression;
-import com.querydsl.core.types.dsl.SimpleExpression;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,7 +20,7 @@ public interface ArticleRepository extends
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {
         bindings.excludeUnlistedProperties(true);
-        bindings.including(root.title,root.hashtag, root.createdAt, root.createdBy, root.content);
+        bindings.including(root.title, root.hashtag, root.createdAt, root.createdBy, root.content);
         //bindings.bind(root.title).first((path, value) -> path.likeIgnoreCase(value)); // like ${value}
         bindings.bind(root.title).first((path, value) -> path.containsIgnoreCase(value)); // like %${value}%
         bindings.bind(root.content).first((path, value) -> path.containsIgnoreCase(value)); // like %${value}%
@@ -31,8 +30,12 @@ public interface ArticleRepository extends
     }
 
     Page<Article> findByTitleContaining(String title, Pageable pageable);
+
     Page<Article> findByContentContaining(String content, Pageable pageable);
+
     Page<Article> findByUserAccount_UserIdContaining(String userId, Pageable pageable);
+
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
+
     Page<Article> findByHashtag(String hashtag, Pageable pageable);
 }

--- a/src/main/java/com/jpa/board/service/ArticleService.java
+++ b/src/main/java/com/jpa/board/service/ArticleService.java
@@ -2,7 +2,6 @@ package com.jpa.board.service;
 
 import com.jpa.board.domain.type.SearchType;
 import com.jpa.board.dto.ArticleDto;
-import com.jpa.board.dto.ArticleUpdateDto;
 import com.jpa.board.dto.ArticleWithCommentsDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,4 +20,6 @@ public interface ArticleService {
     void updateArticle(ArticleDto dto);
 
     void deleteArticle(long articleId);
+
+    long getArticleCount();
 }

--- a/src/main/java/com/jpa/board/service/ArticleServiceImpl.java
+++ b/src/main/java/com/jpa/board/service/ArticleServiceImpl.java
@@ -207,4 +207,9 @@ public class ArticleServiceImpl implements ArticleService {
     public void deleteArticle(long articleId) {
         articleRepository.deleteById(articleId);
     }
+
+    @Override
+    public long getArticleCount() {
+        return articleRepository.count();
+    }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -33,7 +33,7 @@
         </section>
 
         <article id="article-content" class="col-md-7 col-lg-8">
-            <pre>본문<br><br></pre>
+            <pre>본문</pre>
         </article>
     </div>
 
@@ -84,7 +84,7 @@
     </div>
 
     <div class="row g-5">
-        <nav aria-label="Page navigation example">
+        <nav id="pagination" aria-label="Page navigation">
             <ul class="pagination">
                 <li class="page-item"><a class="page-link" href="#">Previous</a></li>
                 <li class="page-item"><a class="page-link" href="#">Next</a></li>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -4,18 +4,33 @@
     <attr sel="#footer" th:replace="footer :: footer"></attr>
 
     <attr sel="#article-main" th:object="${article}">
-        <attr sel="#article-header/h1" th:text="*{title}" />
-        <attr sel="#nickname" th:text="*{nickname}" />
-        <attr sel="#email" th:text="*{email}" />
-        <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-        <attr sel="#hashtag" th:text="*{hashtag}" />
-        <attr sel="#article-content/pre" th:text="*{content}" />
+        <attr sel="#article-header/h1" th:text="*{title}"/>
+        <attr sel="#nickname" th:text="*{nickname}"/>
+        <attr sel="#email" th:text="*{email}"/>
+        <attr sel="#created-at" th:datetime="*{createdAt}"
+              th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
+        <attr sel="#hashtag" th:text="*{hashtag}"/>
+        <attr sel="#article-content/pre" th:text="*{content}"/>
     </attr>
 
     <attr sel="#article-comments" th:remove="all-but-first">
         <attr sel="li[0]" th:each="articleComment : ${articleComments}">
-            <attr sel="div/strong" th:text="${articleComment.nickname}" />
-            <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-            <attr sel="div/p" th:text="${articleComment.content}" />
+            <attr sel="div/strong" th:text="${articleComment.nickname}"/>
+            <attr sel="div/small/time" th:datetime="${articleComment.createdAt}"
+                  th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
+            <attr sel="div/p" th:text="${articleComment.content}"/>
         </attr>
-    </attr></thlogic>
+    </attr>
+    <attr sel="#pagination">
+        <attr sel="ul">
+            <attr sel="li[0]/a"
+                  th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
+                  th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
+            />
+            <attr sel="li[1]/a"
+                  th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
+                  th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
+            />
+        </attr>
+    </attr>
+</thlogic>

--- a/src/test/java/com/jpa/board/controller/ArticleControllerTest.java
+++ b/src/test/java/com/jpa/board/controller/ArticleControllerTest.java
@@ -93,20 +93,28 @@ class ArticleControllerTest {
         BDDMockito.then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-    @DisplayName("{view} {GET} 게시글 상세 페이지 - 정상 호출")
+    @DisplayName("[view][GET] 게시글 페이지 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
         // given
         Long articleId = 1L;
+        long totalCount = 1L;
+
         BDDMockito.given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentsDto());
+        BDDMockito.given(articleService.getArticleCount()).willReturn(totalCount);
+
         // when
         mvc.perform(MockMvcRequestBuilders.get("/articles/" + articleId))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(MockMvcResultMatchers.view().name("articles/detail"))
                 .andExpect(MockMvcResultMatchers.model().attributeExists("article"))
-                .andExpect(MockMvcResultMatchers.model().attributeExists("articleComments"));
+                .andExpect(MockMvcResultMatchers.model().attributeExists("articleComments"))
+                .andExpect(MockMvcResultMatchers.model().attributeExists("articleComments"))
+                .andExpect(MockMvcResultMatchers.model().attribute("totalCount", totalCount));
+
         BDDMockito.then(articleService).should().getArticle(articleId);
+        BDDMockito.then(articleService).should().getArticleCount();
         // then
     }
 

--- a/src/test/java/com/jpa/board/service/ArticleServiceImplTest.java
+++ b/src/test/java/com/jpa/board/service/ArticleServiceImplTest.java
@@ -170,6 +170,21 @@ class ArticleServiceImplTest {
         BDDMockito.then(articleRepository).should().deleteById(articleId);
     }
 
+    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")
+    @Test
+    void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
+        // Given
+        long expected = 0L;
+        BDDMockito.given(articleRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getArticleCount();
+
+        // Then
+        Assertions.assertThat(actual).isEqualTo(expected);
+        BDDMockito.then(articleRepository).should().count();
+    }
+
 
     private UserAccount createUserAccount() {
         return UserAccount.builder()


### PR DESCRIPTION
'previous`, `next`만 구현하므로 게시판에 비해 단순하지만
첫 글, 마지막 글은 버튼 비활성화 및 가짜 링크 처리해야 해서
타임리프 문법이 복잡해짐

마지막 글을 판단하기 위해 총 글 개수가 필요해졌고
이를 위해 count 쿼리 사용, 서비스 로직 추가

this.closes #23 